### PR TITLE
Bundle and re-sign libusb for the signed macOS CLI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -218,16 +218,63 @@ jobs:
             ./scripts/sign_and_notarize.sh "$APP_PATH" --notarize
           fi
 
-          # Sign CLI and its bundled lsl.framework
+          # Sign CLI and its bundled lsl.framework + libusb
           CLI_PATH=$(find packages -name "MCCOutletCLI" -type f | head -1)
           if [[ -n "$CLI_PATH" ]]; then
             CLI_DIR=$(dirname "$CLI_PATH")
-            # Sign framework first (dependency must be signed before dependent)
+            mkdir -p "$CLI_DIR/Frameworks"
+
+            # -----------------------------------------------------------------
+            # Bundle libusb next to the CLI, exactly like lsl.framework.
+            #
+            # The CLI links libusb by an absolute Homebrew path. Once the CLI
+            # is Developer-ID signed with the hardened runtime it is subject to
+            # library validation and may only load dylibs signed by Apple or
+            # the same Team ID. Homebrew's libusb bottle is signed by a
+            # different team, so dyld refuses it unconditionally and the signed
+            # CLI is unrunnable on every machine. Fix: copy libusb in, normalize
+            # its install name to @rpath (resolved via the CLI's existing
+            # @executable_path/Frameworks rpath), repoint the CLI, and sign it
+            # with our identity BEFORE the CLI (dependency before dependent).
+            # -----------------------------------------------------------------
+            LIBUSB_DEST="$CLI_DIR/Frameworks/libusb-1.0.0.dylib"
+            if [[ ! -f "$LIBUSB_DEST" ]]; then
+              # Prefer the copy macdeployqt already placed in the app bundle,
+              # otherwise fall back to the reference the CLI currently links
+              # (brew prefix differs: arm64 /opt/homebrew, x86_64 /usr/local).
+              APP_LIBUSB=$(find packages -path "*.app/Contents/Frameworks/libusb-1.0.0.dylib" -type f | head -1)
+              if [[ -n "$APP_LIBUSB" ]]; then
+                cp "$APP_LIBUSB" "$LIBUSB_DEST"
+              else
+                cp "$(otool -L "$CLI_PATH" | awk '/libusb-1\.0\.0\.dylib/{print $1; exit}')" "$LIBUSB_DEST"
+              fi
+              chmod u+w "$LIBUSB_DEST"
+            fi
+            install_name_tool -id @rpath/libusb-1.0.0.dylib "$LIBUSB_DEST"
+
+            # Repoint the CLI from the absolute brew path to the bundled copy.
+            CLI_LIBUSB_REF=$(otool -L "$CLI_PATH" | awk '/libusb-1\.0\.0\.dylib/{print $1; exit}')
+            if [[ -n "$CLI_LIBUSB_REF" && "$CLI_LIBUSB_REF" != "@rpath/libusb-1.0.0.dylib" ]]; then
+              install_name_tool -change "$CLI_LIBUSB_REF" @rpath/libusb-1.0.0.dylib "$CLI_PATH"
+            fi
+
+            # Sign bundled dependencies first (must precede the dependent CLI).
             if [[ -d "$CLI_DIR/Frameworks/lsl.framework" ]]; then
               codesign --force --sign "$APPLE_CODE_SIGN_IDENTITY_APP" --options runtime \
                 "$CLI_DIR/Frameworks/lsl.framework"
             fi
+            codesign --force --sign "$APPLE_CODE_SIGN_IDENTITY_APP" --options runtime \
+              "$LIBUSB_DEST"
+
             ./scripts/sign_and_notarize.sh "$CLI_PATH" --notarize
+
+            # Guardrail: a signed CLI that still links an absolute brew dylib is
+            # dead on arrival under library validation. Fail the build instead.
+            if otool -L "$CLI_PATH" | grep -qE '/(opt/homebrew|usr/local)/'; then
+              echo "ERROR: signed CLI links non-bundled dylibs:"
+              otool -L "$CLI_PATH"
+              exit 1
+            fi
           fi
 
       # -----------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The released `MCCOutletCLI` from the signed macOS tarball is **dead on arrival on every machine** — even ones with `brew install libusb`:

```
dyld[…]: Library not loaded: /opt/homebrew/opt/libusb/lib/libusb-1.0.0.dylib
  Reason: … code signature … not valid for use in process:
  mapping process and mapped file (non-platform) have different Team IDs
```

The GUI app is fine; only the CLI is broken.

### Root cause

Two facts combine:

1. The CLI links libusb by **absolute Homebrew path** (`otool -L` shows `/opt/homebrew/opt/libusb/lib/libusb-1.0.0.dylib`). `lsl.framework` gets bundled + `@rpath`-fixed-up correctly, but **libusb had no equivalent bundling step**.
2. The release CLI is **Developer-ID signed with the hardened runtime**, which enforces **library validation**: a process may only load dylibs signed by Apple or the *same Team ID*. Homebrew's libusb bottle is signed by a different team, so dyld refuses it unconditionally. No end-user `brew install` can fix it — the binary is unrunnable by construction.

### Why CI didn't catch it

The `MCCOutletCLI --help` smoke tests run in the **build job**, *before* the `sign-macos` job adds the hardened runtime, on a runner that has brew libusb. Unsigned/non-hardened binaries can load cross-team dylibs, so the pre-signing test passes, then signing silently breaks the shipped artifact.

## Fix

In the `sign-macos` job, before `sign_and_notarize.sh` runs on the CLI, treat libusb exactly like `lsl.framework`:

1. **Copy** `libusb-1.0.0.dylib` into the CLI's `Frameworks/` dir — preferring the copy macdeployqt already placed in `MCCOutlet.app`, falling back to whatever reference the CLI currently links (handles arm64 `/opt/homebrew` vs x86_64 `/usr/local`).
2. **Normalize** its install name to `@rpath/libusb-1.0.0.dylib` (resolved via the CLI's existing `@executable_path/Frameworks` rpath).
3. **Repoint** the CLI with `install_name_tool -change`, resolving the current reference dynamically.
4. **Sign the dylib** with the Developer ID before the CLI (dependency before dependent), same as the framework.
5. **Guardrail:** after signing, fail the build if the CLI still links any absolute brew dylib.

The dylib ships automatically — `Frameworks` is already in the release tarball.

## Verification

Manually validated the equivalent steps against the v3.2.0 asset on both a dev Mac and a deployed study computer: after the repoint + re-sign the CLI runs and enumerates an attached USB-1608FS-Plus. Once this ships, the downstream [brnbci-deploy workaround](https://github.com/BlackrockNeurotech/brnbci-deploy/pull/3) that repoints + re-signs the binary post-download becomes a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)